### PR TITLE
This extends compatibility with plugins like Memberpress

### DIFF
--- a/controllers/core.php
+++ b/controllers/core.php
@@ -61,6 +61,14 @@ class JSON_API_Core_Controller {
   public function get_post() {
     global $json_api, $post;
     $post = $json_api->introspector->get_current_post();
+	    if ($json_api->query->cookie) {
+      $user_id = wp_validate_auth_cookie($json_api->query->cookie, 'logged_in');
+      if ($user_id) {
+        $user = get_userdata($user_id);
+
+        wp_set_current_user($user->ID, $user->user_login);
+      }
+    }
     if ($post) {
       $previous = get_adjacent_post(false, '', true);
       $next = get_adjacent_post(false, '', false);


### PR DESCRIPTION
Plugins like memberpress will not allow content to be pulled via api without authentication. This will allow you to authenticate using cookie. Example usage: http://localhost/api/get_post/?id=13&cookie=john|1590919258|xxxxx